### PR TITLE
Revert to working version of changeset action

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v1.4.9
         with:
           cwd: ./vscode
           publish: "./node_modules/.bin/vsce publish -p ${{ secrets.VSCE_PAT }} --no-dependencies"

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeinbox",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeinbox",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "ISC",
       "dependencies": {
         "@supabase/supabase-js": "^2.38.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codeinbox",
   "displayName": "CodeInbox - Stay in the zone, not in the dark",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "View real-time updates from event sources such as Claude Code, and others, for a more productive workflow.",
   "main": "dist/node/extension.js",
   "engines": {


### PR DESCRIPTION
As described here: https://github.com/changesets/action/issues/501

Latest version of the `changesets` action has issues with reading from the `cwd` parameter, which we make use of. Downgrading the version fixes it.